### PR TITLE
Update runtime version from 47 to 48

### DIFF
--- a/io.github.idevecore.Valuta.json
+++ b/io.github.idevecore.Valuta.json
@@ -1,7 +1,7 @@
 {
   "app-id" : "io.github.idevecore.Valuta",
   "runtime" : "org.gnome.Platform",
-  "runtime-version" : "47",
+  "runtime-version" : "48",
   "sdk" : "org.gnome.Sdk",
   "command" : "valuta",
   "finish-args" : [


### PR DESCRIPTION
Gnome runtime 47 is officially deprecated now leading to 
<img width="567" height="85" alt="image" src="https://github.com/user-attachments/assets/c378cd7e-48d1-483e-813d-d78b716fafcc" />


Fixes https://github.com/ideveCore/Valuta/issues/66